### PR TITLE
Awolden/timing and event fixes

### DIFF
--- a/examples/ble_t1000_custom_vars.py
+++ b/examples/ble_t1000_custom_vars.py
@@ -4,7 +4,7 @@ import asyncio
 from meshcore import MeshCore
 from meshcore import BLEConnection
 
-ADDRESS = "T1000_S" # node ble adress or name
+ADDRESS = "Meshcore-lora-py-tester" # node ble adress or name
 
 async def main () :
     con  = BLEConnection(ADDRESS)

--- a/examples/ble_t1000_custom_vars.py
+++ b/examples/ble_t1000_custom_vars.py
@@ -4,7 +4,7 @@ import asyncio
 from meshcore import MeshCore
 from meshcore import BLEConnection
 
-ADDRESS = "Meshcore-lora-py-tester" # node ble adress or name
+ADDRESS = "T1000_S" # node ble adress or name
 
 async def main () :
     con  = BLEConnection(ADDRESS)

--- a/src/meshcore/ble_cx.py
+++ b/src/meshcore/ble_cx.py
@@ -49,7 +49,8 @@ class BLEConnection:
         if self.client:
             logger.debug("Using pre-configured BleakClient.")
             # If a client is already provided, ensure its disconnect callback is set
-            self.client._disconnected_callback = self.handle_disconnect
+            assert isinstance(self.client, BleakClient)
+            self.client.set_disconnected_callback(self.handle_disconnect)
             self.address = self.client.address
         else:
 

--- a/src/meshcore/events.py
+++ b/src/meshcore/events.py
@@ -145,7 +145,7 @@ class EventDispatcher:
                                 for key, value in subscription.attribute_filters.items()):
                             continue
                     
-                    # Fire and forget - don't await!
+                    # Fire the call back asychronously
                     asyncio.create_task(self._execute_callback(subscription.callback, event.clone()))
                         
             self.queue.task_done()

--- a/src/meshcore/serial_cx.py
+++ b/src/meshcore/serial_cx.py
@@ -20,6 +20,7 @@ class SerialConnection:
         self.inframe = b""
         self._disconnect_callback = None
         self.cx_dly = cx_dly
+        self._connected_event = asyncio.Event()
 
     class MCSerialClientProtocol(asyncio.Protocol):
         def __init__(self, cx):
@@ -30,12 +31,16 @@ class SerialConnection:
             logger.debug('port opened')
             if isinstance(transport, serial_asyncio.SerialTransport) and transport.serial:
                 transport.serial.rts = False  # You can manipulate Serial object via transport
+            # Signal that connection is established
+            self.cx._connected_event.set()
     
         def data_received(self, data):
             self.cx.handle_rx(data)    
     
         def connection_lost(self, exc):
             logger.debug('Serial port closed')
+            # Clear the connected event
+            self.cx._connected_event.clear()
             if self.cx._disconnect_callback:
                 asyncio.create_task(self.cx._disconnect_callback("serial_disconnect"))
     
@@ -49,12 +54,16 @@ class SerialConnection:
         """
         Connects to the device
         """
+        # Clear any previous connection state
+        self._connected_event.clear()
+        
         loop = asyncio.get_running_loop()
         await serial_asyncio.create_serial_connection(
                 loop, lambda: self.MCSerialClientProtocol(self), 
                 self.port, baudrate=self.baudrate)
 
-        await asyncio.sleep(self.cx_dly) # wait for cx to establish
+        # Wait for the actual connection to be established
+        await self._connected_event.wait()
         logger.info("Serial Connection started")
         return self.port
 
@@ -99,6 +108,8 @@ class SerialConnection:
         if self.transport:
             self.transport.close()
             self.transport = None
+            # Clear the connected event
+            self._connected_event.clear()
             logger.debug("Serial Connection closed")
             
     def set_disconnect_callback(self, callback):

--- a/src/meshcore/serial_cx.py
+++ b/src/meshcore/serial_cx.py
@@ -31,7 +31,6 @@ class SerialConnection:
             logger.debug('port opened')
             if isinstance(transport, serial_asyncio.SerialTransport) and transport.serial:
                 transport.serial.rts = False  # You can manipulate Serial object via transport
-            # Signal that connection is established
             self.cx._connected_event.set()
     
         def data_received(self, data):
@@ -39,7 +38,6 @@ class SerialConnection:
     
         def connection_lost(self, exc):
             logger.debug('Serial port closed')
-            # Clear the connected event
             self.cx._connected_event.clear()
             if self.cx._disconnect_callback:
                 asyncio.create_task(self.cx._disconnect_callback("serial_disconnect"))
@@ -54,7 +52,6 @@ class SerialConnection:
         """
         Connects to the device
         """
-        # Clear any previous connection state
         self._connected_event.clear()
         
         loop = asyncio.get_running_loop()
@@ -62,7 +59,6 @@ class SerialConnection:
                 loop, lambda: self.MCSerialClientProtocol(self), 
                 self.port, baudrate=self.baudrate)
 
-        # Wait for the actual connection to be established
         await self._connected_event.wait()
         logger.info("Serial Connection started")
         return self.port
@@ -108,7 +104,6 @@ class SerialConnection:
         if self.transport:
             self.transport.close()
             self.transport = None
-            # Clear the connected event
             self._connected_event.clear()
             logger.debug("Serial Connection closed")
             

--- a/tests/test_ble_connection.py
+++ b/tests/test_ble_connection.py
@@ -44,6 +44,7 @@ class TestBLEConnection(unittest.TestCase):
         asyncio.run(ble_conn.send(data_to_send))
 
         # Assert
+        assert(isinstance(ble_conn.rx_char, MagicMock))
         ble_conn.rx_char.write_gatt_char.assert_called_once_with(ble_conn.rx_char, data_to_send, response=True)
 
     def _get_mock_bleak_client(self):


### PR DESCRIPTION
* Fixes deadlock issue in events when nesting commands within event callbacks: https://github.com/fdlamotte/meshcore_py/issues/12

* Removes arbitrary sleep in serial cx in favor of a more direction connection signal

* Fixes a couple small lint errors