### PR TITLE
Update README with some missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,13 @@ All commands are async methods that return `Event` objects. Commands are organiz
 | `reboot()` | None | None | Reboot device (no response expected) |
 | **Security** ||||
 | `export_private_key()` | None | `PRIVATE_KEY/DISABLED` | Export device private key (requires PIN auth & enabled firmware) |
+| `import_private_key(key)` | `key: bytes` | `OK` | Import private key to device |
+| **Statistics** ||||
+| `get_stats_core()` | None | `STATS_CORE` | Get core statistics (voltage, uptime, errors, queue length) |
+| `get_stats_radio()` | None | `STATS_RADIO` | Get radio statistics (noise floor, last RSSI/SNR, tx/rx time stats) |
+| `get_stats_packets()` | None | `STATS_PACKETS` | Get packet statistics (rx/tx totals, breakdown by flood vs. direct) |
+| **Advanced Configuration** ||||
+| `set_multi_acks(multi_acks)` | `multi_acks: int` | `OK` | Set multi-acks mode (experimental ack repeats) |
 
 #### Contact Commands (`meshcore.commands.*`)
 
@@ -557,6 +564,9 @@ All commands are async methods that return `Event` objects. Commands are organiz
 | `send_binary_req(dst, bin_data)` | `dst: contact/str/bytes, bin_data: bytes` | `MSG_SENT` | Send binary data request |
 | `send_path_discovery(dst)` | `dst: contact/str/bytes` | `MSG_SENT` | Initiate path discovery |
 | `send_trace(auth_code, tag, flags, path=None)` | `auth_code: int, tag: int, flags: int, path: list` | `MSG_SENT` | Send route trace packet |
+| **Message Retry & Scope** ||||
+| `send_msg_with_retry(dst, msg, ...)` | `dst, msg, timestamp, max_attempts, max_flood_attempts, flood_after, timeout, min_timeout` | `MSG_SENT/None` | Send message with automatic retry and ACK waiting |
+| `set_flood_scope(scope)` | `scope: str` | `OK` | Set flood scope (hash like "#name", "0"/""/"*" to disable, or raw key) |
 
 #### Binary Protocol Commands (`meshcore.commands.*`)
 


### PR DESCRIPTION
Was fiddling with some things and spotted a few commands that didn't make it into the docs. This isn't exhaustive, but I didn't have the context on the others that were missing to safely document them, so I left them out (a number missing in binary protocol).

Stats frame contents taken from https://github.com/meshcore-dev/MeshCore/blob/2228214ded57c2761312730cdeae14b2b31bc5a3/docs/stats_binary_frames.md?plain=1#L37-L108; I assume those map 1:1 with what we get here.

I asked an LLM for an exhaustive search of missing entries and it came up with this — may or may not be helpful:

<details><summary>LLM Slop</summary>

  Missing Binary Protocol Commands

  | Command                                                 | File Location | Description                                      |
  |---------------------------------------------------------|---------------|--------------------------------------------------|
  | req_status_sync(contact, timeout, min_timeout)          | binary.py:19  | Sync version (replaces deprecated req_status)    |
  | req_telemetry_sync(contact, timeout, min_timeout)       | binary.py:48  | Sync version (replaces deprecated req_telemetry) |
  | req_mma_sync(contact, start, end, timeout, min_timeout) | binary.py:77  | Sync version (replaces deprecated req_mma)       |
  | req_acl_sync(contact, timeout, min_timeout)             | binary.py:111 | Sync version (replaces deprecated req_acl)       |
  | req_neighbours_async(contact, ...)                      | binary.py:137 | Request neighbours asynchronously                |
  | req_neighbours_sync(contact, ...)                       | binary.py:164 | Request neighbours synchronously                 |
  | fetch_all_neighbours(contact, ...)                      | binary.py:201 | Fetch all neighbours with pagination             |

  Missing Control Data Commands (new section)

  | Command                                                 | File Location      | Description                  |
  |---------------------------------------------------------|--------------------|------------------------------|
  | send_control_data(control_type, payload)                | control_data.py:13 | Send raw control data packet |
  | send_node_discover_req(filter, prefix_only, tag, since) | control_data.py:21 | Send node discovery request  |

  Missing Event Types

  | Event Type          | String Value          | Description                    |
  |---------------------|-----------------------|--------------------------------|
  | STATS_CORE          | "stats_core"          | Core statistics response       |
  | STATS_RADIO         | "stats_radio"         | Radio statistics response      |
  | STATS_PACKETS       | "stats_packets"       | Packet statistics response     |
  | NEXT_CONTACT        | "next_contact"        | Next contact in paginated list |
  | CONTROL_DATA        | "control_data"        | Control data response          |
  | DISCOVER_RESPONSE   | "discover_response"   | Node discovery response        |
  | NEIGHBOURS_RESPONSE | "neighbours_response" | Neighbours query response      |
</details>