### PR TITLE
add support for recv_errors in STATUS_PACKETS response

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ All commands are async methods that return `Event` objects. Commands are organiz
 | **Statistics** ||||
 | `get_stats_core()` | None | `STATS_CORE` | Get core statistics (voltage, uptime, errors, queue length) |
 | `get_stats_radio()` | None | `STATS_RADIO` | Get radio statistics (noise floor, last RSSI/SNR, tx/rx time stats) |
-| `get_stats_packets()` | None | `STATS_PACKETS` | Get packet statistics (rx/tx totals, breakdown by flood vs. direct) |
+| `get_stats_packets()` | None | `STATS_PACKETS` | Get packet statistics (rx/tx totals, flood vs. direct, recv_errors when present) |
 | **Advanced Configuration** ||||
 | `set_multi_acks(multi_acks)` | `multi_acks: int` | `OK` | Set multi-acks mode (experimental ack repeats) |
 

--- a/examples/ble_stats.py
+++ b/examples/ble_stats.py
@@ -53,6 +53,11 @@ async def main():
         else:
             print("📦 Packet Statistics:")
             print(json.dumps(result.payload, indent=2))
+            recv_errors = result.payload.get("recv_errors")
+            if recv_errors is not None:
+                print(f"  Receive/CRC errors (RadioLib): {recv_errors}")
+            else:
+                print("  Receive/CRC errors (RadioLib): not reported (legacy 26-byte frame)")
         print()
 
     except Exception as e:


### PR DESCRIPTION
Python-side support for the extended packet-stats frame. Companion firmware change: [MeshCore#1531 – Add recv_errors to CMD_GET_STATS STATS_TYPE_PACKETS response](https://github.com/meshcore-dev/MeshCore/pull/1531).

### Changes

- **Reader:** Accept both 26-byte (legacy) and 30-byte frames; parse optional `recv_errors` (bytes 26–30, RadioLib receive/CRC errors). Emit `recv_errors` in the payload (value or `None` for legacy).
- **Examples:** `ble_stats.py` shows `recv_errors` when present and a “not reported (legacy 26-byte frame)” line otherwise
- **Docs:** README updated to mention `recv_errors` in packet stats.

### Compatibility

- Devices sending the legacy 26-byte frame: `recv_errors` is `None`; behavior unchanged.
- Devices sending the 30-byte frame: `recv_errors` is the uint32 value.
