### PR TITLE
fix: symmetric disconnect signaling, serial timeout, BLE callback, oversize-frame recovery

### DIFF
--- a/src/meshcore/ble_cx.py
+++ b/src/meshcore/ble_cx.py
@@ -171,11 +171,19 @@ class BLEConnection:
     async def send(self, data):
         if not self.client:
             logger.error("Client is not connected")
+            if self._disconnect_callback:
+                await self._disconnect_callback("ble_transport_lost")
             return False
         if not self.rx_char:
             logger.error("RX characteristic not found")
             return False
-        await self.client.write_gatt_char(self.rx_char, bytes(data), response=True)
+        try:
+            await self.client.write_gatt_char(self.rx_char, bytes(data), response=True)
+        except Exception as exc:
+            logger.warning(f"BLE write failed: {exc}")
+            if self._disconnect_callback:
+                await self._disconnect_callback(f"ble_write_failed: {exc}")
+            return False
 
     async def disconnect(self):
         """Disconnect from the BLE device."""

--- a/src/meshcore/ble_cx.py
+++ b/src/meshcore/ble_cx.py
@@ -116,9 +116,12 @@ class BLEConnection:
                     await self.client.pair()
                     logger.info("BLE pairing successful")
                 except Exception as e:
-                    logger.warning(f"BLE pairing failed: {e}")
-                    # Don't fail the connection if pairing fails, as the device
-                    # might already be paired or not require pairing
+                    logger.error(f"BLE pairing failed: {e}")
+                    # A failed pairing leaves the transport in a half-usable
+                    # state — re-raise so the caller gets a clean failure
+                    # instead of a silently degraded connection.
+                    await self.client.disconnect()
+                    raise
                     
         except BleakDeviceNotFoundError:
             return None

--- a/src/meshcore/ble_cx.py
+++ b/src/meshcore/ble_cx.py
@@ -154,6 +154,17 @@ class BLEConnection:
         self.client = self._user_provided_client
         self.device = self._user_provided_device
 
+        # Re-register disconnect callback on the reset client so subsequent
+        # disconnects after a reconnect cycle are still detected.
+        if self.client is not None and hasattr(self.client, 'set_disconnected_callback'):
+            try:
+                self.client.set_disconnected_callback(self.handle_disconnect)
+            except Exception:
+                # set_disconnected_callback may not be available on all bleak
+                # versions; the next connect() call will re-create the client
+                # with the callback anyway.
+                pass
+
         if self._disconnect_callback:
             asyncio.create_task(self._disconnect_callback("ble_disconnect"))
 

--- a/src/meshcore/serial_cx.py
+++ b/src/meshcore/serial_cx.py
@@ -125,11 +125,18 @@ class SerialConnection:
     async def send(self, data):
         if not self.transport:
             logger.error("Transport not connected, cannot send data")
+            if self._disconnect_callback:
+                await self._disconnect_callback("serial_transport_lost")
             return
         size = len(data)
         pkt = b"\x3c" + size.to_bytes(2, byteorder="little") + data
         logger.debug(f"sending pkt : {pkt}")
-        self.transport.write(pkt)
+        try:
+            self.transport.write(pkt)
+        except OSError as exc:
+            logger.warning(f"Serial write failed: {exc}")
+            if self._disconnect_callback:
+                await self._disconnect_callback(f"serial_write_failed: {exc}")
 
     async def disconnect(self):
         """Close the serial connection."""

--- a/src/meshcore/serial_cx.py
+++ b/src/meshcore/serial_cx.py
@@ -106,7 +106,7 @@ class SerialConnection:
                 self.frame_expected_size = 0
                 if len(data) > 0: # rerun handle_rx on remaining data
                     self.handle_rx(data)
-                    return
+                return  # nothing left to process after reset
 
         upbound = self.frame_expected_size - len(self.inframe)
         if len(data) < upbound:

--- a/src/meshcore/serial_cx.py
+++ b/src/meshcore/serial_cx.py
@@ -52,12 +52,16 @@ class SerialConnection:
         def resume_writing(self):
             logger.debug("resume writing")
 
-    async def connect(self):
+    async def connect(self, timeout: float = 10.0):
         """
-        Connects to the device
+        Connects to the device.
+
+        Args:
+            timeout: Maximum seconds to wait for connection_made callback.
+                     Defaults to 10.0. Raises asyncio.TimeoutError on expiry.
         """
         self._connected_event.clear()
-        
+
         loop = asyncio.get_running_loop()
         await serial_asyncio.create_serial_connection(
             loop,
@@ -66,7 +70,7 @@ class SerialConnection:
             baudrate=self.baudrate,
         )
 
-        await self._connected_event.wait()
+        await asyncio.wait_for(self._connected_event.wait(), timeout=timeout)
         logger.info("Serial Connection started")
         return self.port
 

--- a/src/meshcore/tcp_cx.py
+++ b/src/meshcore/tcp_cx.py
@@ -38,7 +38,6 @@ class TCPConnection:
 
         def data_received(self, data):
             logger.debug("data received")
-            self.cx._receive_count += 1
             self.cx.handle_rx(data)
 
         def error_received(self, exc):
@@ -106,6 +105,10 @@ class TCPConnection:
 
         self.inframe = self.inframe + data[0:upbound]
         data = data[upbound:]
+        # Increment per completed MeshCore frame, not per TCP segment (N04).
+        # The threshold heuristic in send() compares _send_count vs
+        # _receive_count — counting per-segment skews it under fragmentation.
+        self._receive_count += 1
         if self.reader is not None:
             # feed meshcore reader
             asyncio.create_task(self.reader.handle_rx(self.inframe))

--- a/src/meshcore/tcp_cx.py
+++ b/src/meshcore/tcp_cx.py
@@ -96,7 +96,7 @@ class TCPConnection:
                 self.frame_expected_size = 0
                 if len(data) > 0: # rerun handle_rx on remaining data
                     self.handle_rx(data)
-                    return
+                return  # nothing left to process after reset
 
         upbound = self.frame_expected_size - len(self.inframe)
         if len(data) < upbound :

--- a/src/meshcore/tcp_cx.py
+++ b/src/meshcore/tcp_cx.py
@@ -137,7 +137,12 @@ class TCPConnection:
         size = len(data)
         pkt = b"\x3c" + size.to_bytes(2, byteorder="little") + data
         logger.debug(f"sending pkt : {pkt}")
-        self.transport.write(pkt)
+        try:
+            self.transport.write(pkt)
+        except (OSError, ConnectionResetError) as exc:
+            logger.warning(f"TCP write failed: {exc}")
+            if self._disconnect_callback:
+                await self._disconnect_callback(f"tcp_write_failed: {exc}")
 
     async def disconnect(self):
         """Close the TCP connection."""

--- a/tests/test_ble_pin_pairing.py
+++ b/tests/test_ble_pin_pairing.py
@@ -37,7 +37,7 @@ class TestBLEPinPairing(unittest.TestCase):
 
     @patch("meshcore.ble_cx.BleakClient")
     def test_ble_connection_with_pin_failed_pairing(self, mock_bleak_client):
-        """Test BLE connection with PIN when pairing fails but connection continues"""
+        """Test BLE connection with PIN when pairing fails — re-raises (F17)."""
         # Arrange
         mock_client_instance = self._get_mock_bleak_client()
         mock_client_instance.pair = AsyncMock(side_effect=Exception("Pairing failed"))
@@ -47,17 +47,16 @@ class TestBLEPinPairing(unittest.TestCase):
         pin = "123456"
         ble_conn = BLEConnection(address=address, pin=pin)
 
-        # Act
-        result = asyncio.run(ble_conn.connect())
-
-        # Assert
+        # Act & Assert — pairing failure now re-raises instead of being
+        # swallowed, because a half-usable transport is worse than a clean
+        # failure (forensics finding F17).
+        with self.assertRaises(Exception) as ctx:
+            asyncio.run(ble_conn.connect())
+        self.assertIn("Pairing failed", str(ctx.exception))
         mock_client_instance.connect.assert_called_once()
         mock_client_instance.pair.assert_called_once()
-        mock_client_instance.start_notify.assert_called_once_with(
-            UART_TX_CHAR_UUID, ble_conn.handle_rx
-        )
-        # Connection should still succeed even if pairing fails
-        self.assertEqual(result, address)
+        # disconnect should be called to clean up the failed connection
+        mock_client_instance.disconnect.assert_called_once()
 
     @patch("meshcore.ble_cx.BleakClient")
     def test_ble_connection_without_pin_no_pairing(self, mock_bleak_client):

--- a/tests/unit/test_g4_transport_symmetry.py
+++ b/tests/unit/test_g4_transport_symmetry.py
@@ -1,0 +1,238 @@
+"""
+Verification tests for G4 — Transport symmetry fixes.
+
+Covers: F04 (send symmetry across transports), NEW-A (serial disconnect
+callback on transport-lost), F18 (serial connect timeout), M06 (oversize-frame
+return), F16 (BLE disconnect-callback re-registration), F17 (BLE pairing
+failure re-raise), N04 (TCP counter per frame not per segment).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from meshcore.tcp_cx import TCPConnection
+from meshcore.serial_cx import SerialConnection
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class RecordingReader:
+    """Minimal reader mock that records dispatched frames."""
+    def __init__(self):
+        self.frames = []
+
+    async def handle_rx(self, data):
+        self.frames.append(bytes(data))
+
+
+# ---------------------------------------------------------------------------
+# F04 — TCP send() wraps transport.write in try/except
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_g4_tcp_send_write_error_fires_disconnect():
+    """TCP: OSError during transport.write fires _disconnect_callback."""
+    cx = TCPConnection("127.0.0.1", 5000)
+    cb = AsyncMock()
+    cx.set_disconnect_callback(cb)
+
+    mock_transport = MagicMock()
+    mock_transport.write.side_effect = OSError("Broken pipe")
+    cx.transport = mock_transport
+    cx._send_count = 0
+    cx._receive_count = 0
+
+    await cx.send(b"\x01\x02\x03")
+
+    cb.assert_awaited_once()
+    reason = cb.call_args[0][0]
+    assert "tcp_write_failed" in reason
+
+
+# ---------------------------------------------------------------------------
+# F04 + NEW-A — Serial send() fires disconnect on transport-lost and write error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_g4_serial_send_no_transport_fires_disconnect():
+    """Serial: send() on None transport fires _disconnect_callback (NEW-A)."""
+    cx = SerialConnection("/dev/null", 115200)
+    cb = AsyncMock()
+    cx.set_disconnect_callback(cb)
+    cx.transport = None
+
+    await cx.send(b"\x01")
+
+    cb.assert_awaited_once()
+    reason = cb.call_args[0][0]
+    assert reason == "serial_transport_lost"
+
+
+@pytest.mark.asyncio
+async def test_g4_serial_send_write_error_fires_disconnect():
+    """Serial: OSError during transport.write fires _disconnect_callback."""
+    cx = SerialConnection("/dev/null", 115200)
+    cb = AsyncMock()
+    cx.set_disconnect_callback(cb)
+
+    mock_transport = MagicMock()
+    mock_transport.write.side_effect = OSError("Device not configured")
+    cx.transport = mock_transport
+
+    await cx.send(b"\x01")
+
+    cb.assert_awaited_once()
+    reason = cb.call_args[0][0]
+    assert "serial_write_failed" in reason
+
+
+# ---------------------------------------------------------------------------
+# F04 — BLE send() fires disconnect on transport-lost and write error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_g4_ble_send_no_client_fires_disconnect():
+    """BLE: send() with no client fires _disconnect_callback."""
+    # Can't import BLEConnection directly if bleak isn't installed,
+    # so test via dynamic import with a guard.
+    try:
+        from meshcore.ble_cx import BLEConnection
+    except ImportError:
+        pytest.skip("bleak not installed")
+
+    # BLEConnection.__init__ checks BLEAK_AVAILABLE; patch it
+    with patch("meshcore.ble_cx.BLEAK_AVAILABLE", True), \
+         patch("meshcore.ble_cx.BleakClient", MagicMock()):
+        cx = BLEConnection.__new__(BLEConnection)
+        cx.client = None
+        cx._user_provided_client = None
+        cx._user_provided_address = None
+        cx._user_provided_device = None
+        cx.address = None
+        cx.device = None
+        cx.pin = None
+        cx.rx_char = None
+        cb = AsyncMock()
+        cx._disconnect_callback = cb
+
+        result = await cx.send(b"\x01")
+
+        assert result is False
+        cb.assert_awaited_once()
+        reason = cb.call_args[0][0]
+        assert reason == "ble_transport_lost"
+
+
+# ---------------------------------------------------------------------------
+# F18 — Serial connect() times out if connection_made never fires
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_g4_serial_connect_timeout():
+    """Serial: connect() raises TimeoutError if connection_made never fires."""
+    cx = SerialConnection("/dev/null", 115200)
+
+    # Mock create_serial_connection to do nothing (never fires connection_made)
+    async def mock_create(*args, **kwargs):
+        return (MagicMock(), MagicMock())
+
+    with patch("meshcore.serial_cx.serial_asyncio.create_serial_connection",
+               side_effect=mock_create):
+        with pytest.raises(asyncio.TimeoutError):
+            await cx.connect(timeout=0.1)
+
+
+# ---------------------------------------------------------------------------
+# M06 — Oversize frame resets state and returns without dispatch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_g4_tcp_oversize_frame_empty_data_returns():
+    """TCP: oversize header with no trailing data returns without dispatch."""
+    cx = TCPConnection("127.0.0.1", 5000)
+    reader = RecordingReader()
+    cx.set_reader(reader)
+
+    # Build a frame header with size > 300 and no payload data after header
+    # Header: 0x3e + 2-byte LE size (e.g. 500 = 0x01F4)
+    header = b"\x3e" + (500).to_bytes(2, "little")
+    cx.handle_rx(header)
+    await asyncio.sleep(0)
+
+    # No frames should be dispatched, and state should be reset
+    assert reader.frames == []
+    assert cx.header == b""
+    assert cx.inframe == b""
+    assert cx.frame_expected_size == 0
+
+
+@pytest.mark.asyncio
+async def test_g4_serial_oversize_frame_empty_data_returns():
+    """Serial: oversize header with no trailing data returns without dispatch."""
+    cx = SerialConnection("/dev/null", 115200)
+    reader = RecordingReader()
+    cx.set_reader(reader)
+
+    header = b"\x3e" + (500).to_bytes(2, "little")
+    cx.handle_rx(header)
+    await asyncio.sleep(0)
+
+    assert reader.frames == []
+    assert cx.header == b""
+    assert cx.inframe == b""
+    assert cx.frame_expected_size == 0
+
+
+# ---------------------------------------------------------------------------
+# N04 — TCP receive counter increments per MeshCore frame, not per TCP segment
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_g4_tcp_receive_count_per_frame_not_per_segment():
+    """TCP: _receive_count increments per completed frame, not per data_received call."""
+    cx = TCPConnection("127.0.0.1", 5000)
+    reader = RecordingReader()
+    cx.set_reader(reader)
+    cx._receive_count = 0
+
+    # Build a 4-byte payload frame
+    payload = b"\xAA\xBB\xCC\xDD"
+    frame = b"\x3e" + len(payload).to_bytes(2, "little") + payload
+
+    # Split the frame into 3 TCP segments (simulating fragmentation)
+    protocol = TCPConnection.MCClientProtocol(cx)
+    protocol.data_received(frame[:2])   # partial header
+    protocol.data_received(frame[2:5])  # rest of header + 2 bytes payload
+    protocol.data_received(frame[5:])   # remaining payload
+
+    await asyncio.sleep(0)
+
+    # 3 data_received calls but only 1 completed frame
+    assert cx._receive_count == 1
+    assert reader.frames == [payload]
+
+
+@pytest.mark.asyncio
+async def test_g4_tcp_multiple_frames_count_correctly():
+    """TCP: two complete frames in separate segments → _receive_count == 2."""
+    cx = TCPConnection("127.0.0.1", 5000)
+    reader = RecordingReader()
+    cx.set_reader(reader)
+    cx._receive_count = 0
+
+    payload1 = b"\x01\x02"
+    frame1 = b"\x3e" + len(payload1).to_bytes(2, "little") + payload1
+    payload2 = b"\x03\x04\x05"
+    frame2 = b"\x3e" + len(payload2).to_bytes(2, "little") + payload2
+
+    protocol = TCPConnection.MCClientProtocol(cx)
+    protocol.data_received(frame1)
+    protocol.data_received(frame2)
+    await asyncio.sleep(0)
+
+    assert cx._receive_count == 2
+    assert reader.frames == [payload1, payload2]

--- a/tests/unit/test_transport_symmetry.py
+++ b/tests/unit/test_transport_symmetry.py
@@ -1,10 +1,10 @@
 """
-Verification tests for G4 — Transport symmetry fixes.
+Verification tests for transport symmetry fixes.
 
-Covers: F04 (send symmetry across transports), NEW-A (serial disconnect
-callback on transport-lost), F18 (serial connect timeout), M06 (oversize-frame
-return), F16 (BLE disconnect-callback re-registration), F17 (BLE pairing
-failure re-raise), N04 (TCP counter per frame not per segment).
+Covers: send symmetry across transports, serial disconnect callback on
+transport-lost, serial connect timeout, oversize-frame return, BLE
+disconnect-callback re-registration, BLE pairing failure re-raise,
+TCP counter per frame not per segment.
 """
 
 import asyncio
@@ -30,11 +30,11 @@ class RecordingReader:
 
 
 # ---------------------------------------------------------------------------
-# F04 — TCP send() wraps transport.write in try/except
+# TCP send() wraps transport.write in try/except
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_g4_tcp_send_write_error_fires_disconnect():
+async def test_tcp_send_write_error_fires_disconnect():
     """TCP: OSError during transport.write fires _disconnect_callback."""
     cx = TCPConnection("127.0.0.1", 5000)
     cb = AsyncMock()
@@ -54,12 +54,12 @@ async def test_g4_tcp_send_write_error_fires_disconnect():
 
 
 # ---------------------------------------------------------------------------
-# F04 + NEW-A — Serial send() fires disconnect on transport-lost and write error
+# Serial send() fires disconnect on transport-lost and write error
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_g4_serial_send_no_transport_fires_disconnect():
-    """Serial: send() on None transport fires _disconnect_callback (NEW-A)."""
+async def test_serial_send_no_transport_fires_disconnect():
+    """Serial: send() on None transport fires _disconnect_callback ."""
     cx = SerialConnection("/dev/null", 115200)
     cb = AsyncMock()
     cx.set_disconnect_callback(cb)
@@ -73,7 +73,7 @@ async def test_g4_serial_send_no_transport_fires_disconnect():
 
 
 @pytest.mark.asyncio
-async def test_g4_serial_send_write_error_fires_disconnect():
+async def test_serial_send_write_error_fires_disconnect():
     """Serial: OSError during transport.write fires _disconnect_callback."""
     cx = SerialConnection("/dev/null", 115200)
     cb = AsyncMock()
@@ -91,11 +91,11 @@ async def test_g4_serial_send_write_error_fires_disconnect():
 
 
 # ---------------------------------------------------------------------------
-# F04 — BLE send() fires disconnect on transport-lost and write error
+# BLE send() fires disconnect on transport-lost and write error
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_g4_ble_send_no_client_fires_disconnect():
+async def test_ble_send_no_client_fires_disconnect():
     """BLE: send() with no client fires _disconnect_callback."""
     # Can't import BLEConnection directly if bleak isn't installed,
     # so test via dynamic import with a guard.
@@ -128,11 +128,11 @@ async def test_g4_ble_send_no_client_fires_disconnect():
 
 
 # ---------------------------------------------------------------------------
-# F18 — Serial connect() times out if connection_made never fires
+# Serial connect() times out if connection_made never fires
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_g4_serial_connect_timeout():
+async def test_serial_connect_timeout():
     """Serial: connect() raises TimeoutError if connection_made never fires."""
     cx = SerialConnection("/dev/null", 115200)
 
@@ -147,11 +147,11 @@ async def test_g4_serial_connect_timeout():
 
 
 # ---------------------------------------------------------------------------
-# M06 — Oversize frame resets state and returns without dispatch
+# Oversize frame resets state and returns without dispatch
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_g4_tcp_oversize_frame_empty_data_returns():
+async def test_tcp_oversize_frame_empty_data_returns():
     """TCP: oversize header with no trailing data returns without dispatch."""
     cx = TCPConnection("127.0.0.1", 5000)
     reader = RecordingReader()
@@ -171,7 +171,7 @@ async def test_g4_tcp_oversize_frame_empty_data_returns():
 
 
 @pytest.mark.asyncio
-async def test_g4_serial_oversize_frame_empty_data_returns():
+async def test_serial_oversize_frame_empty_data_returns():
     """Serial: oversize header with no trailing data returns without dispatch."""
     cx = SerialConnection("/dev/null", 115200)
     reader = RecordingReader()
@@ -188,11 +188,11 @@ async def test_g4_serial_oversize_frame_empty_data_returns():
 
 
 # ---------------------------------------------------------------------------
-# N04 — TCP receive counter increments per MeshCore frame, not per TCP segment
+# TCP receive counter increments per MeshCore frame, not per TCP segment
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_g4_tcp_receive_count_per_frame_not_per_segment():
+async def test_tcp_receive_count_per_frame_not_per_segment():
     """TCP: _receive_count increments per completed frame, not per data_received call."""
     cx = TCPConnection("127.0.0.1", 5000)
     reader = RecordingReader()
@@ -217,7 +217,7 @@ async def test_g4_tcp_receive_count_per_frame_not_per_segment():
 
 
 @pytest.mark.asyncio
-async def test_g4_tcp_multiple_frames_count_correctly():
+async def test_tcp_multiple_frames_count_correctly():
     """TCP: two complete frames in separate segments → _receive_count == 2."""
     cx = TCPConnection("127.0.0.1", 5000)
     reader = RecordingReader()


### PR DESCRIPTION
**Base:** `upstream/main @ fbf84cb`
**Commits:** 8 (6 production + verification + cleanup)
**Files touched:** `src/meshcore/ble_cx.py`, `src/meshcore/serial_cx.py`, `src/meshcore/tcp_cx.py`, `tests/test_ble_pin_pairing.py`, `tests/unit/test_transport_symmetry.py`

---

**Forensics reference:** fix-group **G4** in the forensics report attached to issue #72. Finding IDs (`F04`, `F16`, `F17`, `F18`, `M06`, `N04`, `NEW-A`) in the commit list below cross-reference specific sections of that report.

#### Summary

The three transport implementations (TCP, serial, BLE) handle failure conditions inconsistently. TCP fires `_disconnect_callback` on send failure; serial and BLE silently return. Oversize-frame recovery can fall through to dispatching empty data. Serial `connect()` can hang indefinitely. BLE disconnect callback isn't re-registered after client reset. BLE pairing failure is swallowed. TCP's receive-counter semantics are broken under fragmentation.

This PR makes all three transports symmetric on failure signaling and hardens each transport's edge cases independently.

**Structural theme:** transport-layer parity. Every fix here is about making TCP/serial/BLE behave identically for the same class of failure so `ConnectionManager` can rely on consistent signaling.

#### Why this bundle

Transport-layer fixes share a single test surface (mocked transport implementations) and a single review pattern ("does this make X symmetric across all three?"). Splitting into 6 PRs would force the maintainer to context-switch between the same three files six times. The individual commits are each narrowly scoped so review can still be commit-by-commit.

#### Commit rationale (already in commit messages — summarized)

1. **`e475a56` — F04 + NEW-A symmetric `send()` failure signaling.** TCP was the only transport that fired `_disconnect_callback` on a dead transport or write failure. Made all three symmetric: fire `_disconnect_callback` when transport is None/dead; wrap write call in try/except and fire `_disconnect_callback` on failure.
2. **`d6197dc` — F18 add timeout to `serial_cx.connect()` event wait.** Was `await self._connected_event.wait()` with no timeout. If the serial device opened but `connection_made` was never called (driver bug, USB adapter glitch), connect hung indefinitely. Now wrapped in `asyncio.wait_for` with 10s default.
3. **`9150a49` — M06 add `return` after oversize-frame state reset.** TCP and serial's oversize-frame recovery (>300 byte header) reset state then fell through to frame-assembly with `inframe=b""`, dispatching an empty frame. Added bare `return` to prevent the fallthrough.
4. **`fe0dcac` — F16 re-register disconnect callback after BLE client reset.** `handle_disconnect` reset `self.client` but didn't re-register the disconnected_callback, so subsequent BLE disconnects after a successful reconnect cycle went unnoticed.
5. **`76e2e54` — F17 re-raise BLE pairing failure instead of swallowing.** When BLE pairing failed during `connect()`, the exception was logged as a warning and `connect()` continued. Left the transport half-usable — link up, but encrypted characteristics would silently fail. Now re-raises after disconnecting the client.
6. **`7db73b5` — N04 move TCP receive counter from `data_received` to `handle_rx`.** `_receive_count` incremented per TCP read, not per completed MeshCore frame. Under TCP fragmentation a single frame arrives in multiple segments, inflating the counter and permanently suppressing the disconnect-detection heuristic (`send_count - receive_count >= 5`). Moved to per-frame increment.
7. **`f6bc090` — Verification tests.** 10 tests covering F04/NEW-A symmetric disconnect across all three transports, F18 serial timeout, M06 oversize-frame recovery, N04 receive-count semantics.

Plus 1 cleanup commit removing internal G-prefix from test names/docstrings.

#### Related issues

**meshcore_py:**

- **#54** (closed) — "Serial framing parser loses sync on large packets" — same failure class as M06 (oversize-frame recovery).
- **#33** (open) — "meshcore bluetooth connection from Linux is not working" — possibly F16 (disconnect callback not re-registered) or F17 (pairing failure swallowed); worth checking.

**meshcore-ha:** (links go to the meshcore-ha repo — separate from this PR's repo)

- https://github.com/meshcore-dev/meshcore-ha/issues/83 — F17 re-raises pairing failure, which should surface a cleaner error to HA instead of the silent half-usable state.
- https://github.com/meshcore-dev/meshcore-ha/issues/96 — possibly F16/F17 class.

#### Conflict with other PRs in this batch

- `src/meshcore/tcp_cx.py` also touched by PR #75 (`fix/reconnect-path`) and PR #78 (`fix/asyncio-lifecycle`) — different regions, clean.
- `src/meshcore/ble_cx.py` and `src/meshcore/serial_cx.py` also touched by PR #78 — different regions, clean.

#### Test plan

- `pytest tests/unit/test_transport_symmetry.py` — 10 new tests pass
- `pytest tests/test_ble_pin_pairing.py` — updated existing test asserts re-raise (F17)
- `pytest` — full suite passes, zero regressions