### PR TITLE
fix: remove broken req_mma, bump DEFAULT_TIMEOUT, guard TypeError, pre-register binary requests

### DIFF
--- a/src/meshcore/commands/base.py
+++ b/src/meshcore/commands/base.py
@@ -243,18 +243,31 @@ class CommandHandlerBase:
         logger.debug(f"Binary request to {dst_bytes.hex()}")
         data = b"\x32" + dst_bytes + request_type.value.to_bytes(1, "little", signed=False) + (data if data else b"")
 
-        result = await self.send(data, [EventType.MSG_SENT, EventType.ERROR])
-        
-        # Register the request with the reader if we have both reader and request_type
-        if (result.type == EventType.MSG_SENT and 
-            self._reader is not None and 
-            request_type is not None):
-            
-            exp_tag = result.payload["expected_ack"].hex()
-            # Use provided timeout or fallback to suggested timeout (with 5s default)
-            actual_timeout = timeout if timeout is not None and timeout > 0 else result.payload.get("suggested_timeout", 4000) / 800.0
+        # Pre-register a placeholder binary request before send() to close the race
+        # window where a BINARY_RESPONSE could arrive between send() returning and
+        # registration. The placeholder tag is patched to the real tag once MSG_SENT
+        # returns. If send() fails, the placeholder is cleaned up.
+        placeholder_tag = None
+        if self._reader is not None and request_type is not None:
+            placeholder_tag = f"_pending_{id(data)}"
+            actual_timeout = timeout if timeout is not None and timeout > 0 else self.default_timeout
             actual_timeout = min_timeout if actual_timeout < min_timeout else actual_timeout
-            self._reader.register_binary_request(pubkey_prefix.hex(), exp_tag, request_type, actual_timeout, context=context)
+            self._reader.register_binary_request(pubkey_prefix.hex(), placeholder_tag, request_type, actual_timeout, context=context)
+
+        result = await self.send(data, [EventType.MSG_SENT, EventType.ERROR])
+
+        # Patch the placeholder tag with the real tag from MSG_SENT, or clean up on failure
+        if placeholder_tag is not None and self._reader is not None:
+            # Remove the placeholder entry
+            self._reader.pending_binary_requests.pop(placeholder_tag, None)
+            if (result.type == EventType.MSG_SENT and
+                    request_type is not None):
+                exp_tag = result.payload["expected_ack"].hex()
+                # Use suggested_timeout from the result if available
+                actual_timeout = timeout if timeout is not None and timeout > 0 else result.payload.get("suggested_timeout", 4000) / 800.0
+                actual_timeout = min_timeout if actual_timeout < min_timeout else actual_timeout
+                # Register with the real tag
+                self._reader.register_binary_request(pubkey_prefix.hex(), exp_tag, request_type, actual_timeout, context=context)
 
         return result
 

--- a/src/meshcore/commands/base.py
+++ b/src/meshcore/commands/base.py
@@ -58,7 +58,7 @@ def _validate_destination(dst: DestinationType, prefix_length: int = 6) -> bytes
 
 
 class CommandHandlerBase:
-    DEFAULT_TIMEOUT = 5.0
+    DEFAULT_TIMEOUT = 15.0
 
     def __init__(self, default_timeout: Optional[float] = None):
         self._sender_func: Optional[Callable[[bytes], Coroutine[Any, Any, None]]] = None

--- a/src/meshcore/commands/binary.py
+++ b/src/meshcore/commands/binary.py
@@ -73,10 +73,6 @@ class BinaryCommandHandler(CommandHandlerBase):
 
             return telem_event.payload["lpp"] if telem_event else None
 
-    async def req_mma(self, contact, timeout=0, min_timeout=0):
-        logger.error("*** please consider using req_mma_sync instead of req_mma") 
-        return await self.req_mma_sync(contact, start, end, timeout,min_timeout)
-
     async def req_mma_sync(self, contact, start, end, timeout=0,min_timeout=0):
         async with self._mesh_request_lock:
             req = (

--- a/src/meshcore/commands/contact.py
+++ b/src/meshcore/commands/contact.py
@@ -43,13 +43,17 @@ class ContactCommands(CommandHandlerBase):
                     logger.debug("Timeout while getting contacts")
                     for future in pending: # cancel all futures
                         future.cancel()
-                    return None
+                    return Event(EventType.ERROR, {"reason": "timeout waiting for contacts"})
 
                 for future in done:
                     event = await future
-                    if event is None or event.type != EventType.NEXT_CONTACT:
-                        for future in pending:
-                            future.cancel()
+                    if event is None:
+                        for f in pending:
+                            f.cancel()
+                        return Event(EventType.ERROR, {"reason": "no event received during contacts retrieval"})
+                    if event.type != EventType.NEXT_CONTACT:
+                        for f in pending:
+                            f.cancel()
                         return event
 
                 futures = []
@@ -64,7 +68,7 @@ class ContactCommands(CommandHandlerBase):
     
         except asyncio.TimeoutError:
             logger.debug(f"Timeout receiving contacts")
-            return None
+            return Event(EventType.ERROR, {"reason": "asyncio timeout receiving contacts"})
         except Exception as e:
             logger.debug(f"Command error: {e}")
             return Event(EventType.ERROR, {"error": str(e)})
@@ -116,7 +120,9 @@ class ContactCommands(CommandHandlerBase):
                     path_hash_mode = int(path.split(":")[1])
                     path = path.split(":")[0].replace(":","")
                 else: # use device one by default
-                    path_hash_mode = contact["out_path_len"] >> 6 # would fallback to previous val
+                    # out_path_len is pre-masked (& 0x3F) in reader.py, so high bits are always 0;
+                    # the actual path_hash_mode is fetched from the device query below.
+                    path_hash_mode = 0
                     res = await self.send_device_query()
                     if not res is None and res.type != EventType.ERROR:
                         if "path_hash_mode" in res.payload:

--- a/src/meshcore/commands/messaging.py
+++ b/src/meshcore/commands/messaging.py
@@ -313,6 +313,8 @@ class MessagingCommands(CommandHandlerBase):
         elif isinstance (scope, bytes): # scope has been sent directly as byte
                 logger.debug(f"Directly setting scope to {scope}")
                 scope_key = scope
+        else:
+            raise TypeError(f"set_flood_scope: unsupported scope type {type(scope).__name__}")
 
         logger.debug(f"Setting scope to {scope_key.hex()}")
 

--- a/src/meshcore/meshcore.py
+++ b/src/meshcore/meshcore.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Callable, Coroutine, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from .events import Event, EventDispatcher, EventType, Subscription
 from .reader import MessageReader
@@ -206,7 +206,7 @@ class MeshCore:
     def subscribe(
         self,
         event_type: Union[EventType, None],
-        callback: Callable[[Event], Coroutine[Any, Any, None]],
+        callback: Callable[[Event], Union[None, asyncio.Future]],
         attribute_filters: Optional[Dict[str, Any]] = None,
     ) -> Subscription:
         """

--- a/tests/unit/test_g7_standalone_bugs_and_cleanup.py
+++ b/tests/unit/test_g7_standalone_bugs_and_cleanup.py
@@ -1,0 +1,216 @@
+"""
+Verification tests for G7 — Standalone bugs and cleanup.
+Findings: F13, F09, M03, M05, M07, R03, R05.
+"""
+
+import pytest
+import asyncio
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from meshcore.events import Event, EventDispatcher, EventType
+from meshcore.commands.base import CommandHandlerBase
+from meshcore.commands.binary import BinaryCommandHandler
+from meshcore.commands.messaging import MessagingCommands
+from meshcore.commands.contact import ContactCommands
+from meshcore.meshcore import MeshCore
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── F13: req_mma removed ──────────────────────────────────────────────────────
+
+def test_f13_req_mma_removed():
+    """F13: The broken req_mma method should no longer exist on BinaryCommandHandler."""
+    assert not hasattr(BinaryCommandHandler, "req_mma"), \
+        "req_mma should be removed — it had NameError on undefined start/end"
+
+
+def test_f13_req_mma_sync_still_exists():
+    """F13: req_mma_sync should still be present and functional."""
+    assert hasattr(BinaryCommandHandler, "req_mma_sync"), \
+        "req_mma_sync should still exist after removing req_mma"
+
+
+# ── F09: DEFAULT_TIMEOUT bumped ───────────────────────────────────────────────
+
+def test_f09_default_timeout_bumped():
+    """F09: DEFAULT_TIMEOUT should be 15.0, not the old 5.0."""
+    assert CommandHandlerBase.DEFAULT_TIMEOUT == 15.0, \
+        f"DEFAULT_TIMEOUT is {CommandHandlerBase.DEFAULT_TIMEOUT}, expected 15.0"
+
+
+def test_f09_instance_default_timeout():
+    """F09: Instance default_timeout should inherit the new 15.0 value."""
+    handler = CommandHandlerBase()
+    assert handler.default_timeout == 15.0
+
+
+def test_f09_custom_timeout_still_works():
+    """F09: Passing a custom timeout should still override the default."""
+    handler = CommandHandlerBase(default_timeout=30.0)
+    assert handler.default_timeout == 30.0
+
+
+# ── M03: set_flood_scope TypeError guard ──────────────────────────────────────
+
+async def test_m03_set_flood_scope_bad_type_raises():
+    """M03: Passing an unsupported type (e.g., int) should raise TypeError."""
+    handler = MessagingCommands()
+    with pytest.raises(TypeError, match="unsupported scope type"):
+        await handler.set_flood_scope(42)
+
+
+async def test_m03_set_flood_scope_bad_type_bytearray():
+    """M03: bytearray is not bytes — should raise TypeError."""
+    handler = MessagingCommands()
+    with pytest.raises(TypeError, match="unsupported scope type"):
+        await handler.set_flood_scope(bytearray(b"\x00" * 16))
+
+
+async def test_m03_set_flood_scope_none_still_works():
+    """M03: None scope should reach send() without TypeError — verifies the None branch still binds scope_key."""
+    handler = MessagingCommands()
+    handler._sender_func = AsyncMock()
+    handler.dispatcher = EventDispatcher()
+    await handler.dispatcher.start()
+    try:
+        # Dispatch an OK event so send() resolves
+        async def _dispatch_ok():
+            await asyncio.sleep(0.05)
+            await handler.dispatcher.dispatch(Event(EventType.OK, {}))
+        asyncio.ensure_future(_dispatch_ok())
+        result = await handler.set_flood_scope(None)
+        assert result.type == EventType.OK
+    finally:
+        handler.dispatcher.running = False
+
+
+async def test_m03_set_flood_scope_str_still_works():
+    """M03: String scope should reach send() without TypeError."""
+    handler = MessagingCommands()
+    handler._sender_func = AsyncMock()
+    handler.dispatcher = EventDispatcher()
+    await handler.dispatcher.start()
+    try:
+        async def _dispatch_ok():
+            await asyncio.sleep(0.05)
+            await handler.dispatcher.dispatch(Event(EventType.OK, {}))
+        asyncio.ensure_future(_dispatch_ok())
+        result = await handler.set_flood_scope("#test")
+        assert result.type == EventType.OK
+    finally:
+        handler.dispatcher.running = False
+
+
+async def test_m03_set_flood_scope_bytes_still_works():
+    """M03: Bytes scope should reach send() without TypeError."""
+    handler = MessagingCommands()
+    handler._sender_func = AsyncMock()
+    handler.dispatcher = EventDispatcher()
+    await handler.dispatcher.start()
+    try:
+        async def _dispatch_ok():
+            await asyncio.sleep(0.05)
+            await handler.dispatcher.dispatch(Event(EventType.OK, {}))
+        asyncio.ensure_future(_dispatch_ok())
+        result = await handler.set_flood_scope(b"\x01" * 16)
+        assert result.type == EventType.OK
+    finally:
+        handler.dispatcher.running = False
+
+
+# ── M05: dead path_hash_mode shift removed ────────────────────────────────────
+
+def test_m05_no_shift_in_update_contact():
+    """M05: The dead `>> 6` shift on out_path_len should not appear in contact.py."""
+    import meshcore.commands.contact as contact_mod
+    source = inspect.getsource(contact_mod.ContactCommands.update_contact)
+    assert ">> 6" not in source, \
+        "Dead path_hash_mode = out_path_len >> 6 shift should be removed"
+
+
+# ── M07: get_contacts returns Event, never None ───────────────────────────────
+
+async def test_m07_get_contacts_timeout_returns_error_event():
+    """M07: On timeout (no futures complete), get_contacts should return an Error Event, not None."""
+    handler = ContactCommands()
+    handler._sender_func = AsyncMock()
+    handler._reader = MagicMock()
+    handler.dispatcher = MagicMock()
+    # Make wait_for_event always timeout by never returning
+    handler.dispatcher.wait_for_event = AsyncMock(side_effect=asyncio.TimeoutError)
+
+    result = await handler.get_contacts(timeout=0.1)
+    assert result is not None, "get_contacts should never return None"
+    assert isinstance(result, Event)
+    assert result.type == EventType.ERROR
+
+
+# ── R03: binary request pre-registration ──────────────────────────────────────
+
+async def test_r03_placeholder_registered_before_send():
+    """R03: A placeholder binary request should be registered before send() is called."""
+    from meshcore.packets import BinaryReqType
+
+    handler = CommandHandlerBase()
+    handler._sender_func = AsyncMock()
+
+    # Track registration calls
+    mock_reader = MagicMock()
+    mock_reader.pending_binary_requests = {}
+    original_register = MagicMock()
+
+    registration_order = []
+    send_called = False
+
+    async def mock_send(data):
+        nonlocal send_called
+        # At the point send() is called, a placeholder should already exist
+        registration_order.append(("send", len(mock_reader.pending_binary_requests)))
+        send_called = True
+
+    handler._sender_func = mock_send
+    handler._reader = mock_reader
+    handler.dispatcher = MagicMock()
+    handler.dispatcher.wait_for_event = AsyncMock(
+        return_value=Event(EventType.MSG_SENT, {"expected_ack": b"\x01\x02\x03\x04"})
+    )
+
+    # Call send_binary_req
+    dst = "aa" * 32  # 32-byte hex pubkey
+    await handler.send_binary_req(dst, BinaryReqType.MMA)
+
+    # Verify register_binary_request was called (at least the placeholder)
+    assert mock_reader.register_binary_request.call_count >= 1, \
+        "register_binary_request should be called at least once for the placeholder"
+
+
+# ── R05: MeshCore.subscribe annotation matches EventDispatcher ────────────────
+
+def test_r05_subscribe_annotation_matches_dispatcher():
+    """R05: MeshCore.subscribe callback annotation should match EventDispatcher.subscribe."""
+    mc_hints = MeshCore.subscribe.__annotations__
+    ed_hints = EventDispatcher.subscribe.__annotations__
+
+    # Both should have 'callback' in their annotations
+    assert "callback" in mc_hints, "MeshCore.subscribe missing callback annotation"
+    assert "callback" in ed_hints, "EventDispatcher.subscribe missing callback annotation"
+
+    # The callback annotations should be identical
+    assert mc_hints["callback"] == ed_hints["callback"], (
+        f"MeshCore.subscribe callback annotation {mc_hints['callback']} "
+        f"does not match EventDispatcher.subscribe {ed_hints['callback']}"
+    )
+
+
+def test_r05_no_coroutine_import_in_meshcore():
+    """R05: After widening the annotation, Coroutine should no longer be imported in meshcore.py."""
+    import meshcore.meshcore as mc_mod
+    source = inspect.getsource(mc_mod)
+    # Check the import line specifically — Coroutine should not be in the typing imports
+    for line in source.splitlines():
+        if line.startswith("from typing import"):
+            assert "Coroutine" not in line, \
+                "Coroutine should be removed from typing imports in meshcore.py"
+            break

--- a/tests/unit/test_g7_standalone_bugs_and_cleanup.py
+++ b/tests/unit/test_g7_standalone_bugs_and_cleanup.py
@@ -177,6 +177,16 @@ async def test_r03_placeholder_registered_before_send():
         return_value=Event(EventType.MSG_SENT, {"expected_ack": b"\x01\x02\x03\x04"})
     )
 
+    # Resolve subscribed events immediately so send() doesn't block
+    def resolving_subscribe(event_type, cb, attribute_filters=None):
+        sub = MagicMock()
+        sub.unsubscribe = MagicMock()
+        asyncio.get_event_loop().call_soon(
+            cb, Event(event_type, {})
+        )
+        return sub
+    handler.dispatcher.subscribe = MagicMock(side_effect=resolving_subscribe)
+
     # Call send_binary_req
     dst = "aa" * 32  # 32-byte hex pubkey
     await handler.send_binary_req(dst, BinaryReqType.MMA)

--- a/tests/unit/test_g7_standalone_bugs_and_cleanup.py
+++ b/tests/unit/test_g7_standalone_bugs_and_cleanup.py
@@ -177,12 +177,14 @@ async def test_r03_placeholder_registered_before_send():
         return_value=Event(EventType.MSG_SENT, {"expected_ack": b"\x01\x02\x03\x04"})
     )
 
-    # Resolve subscribed events immediately so send() doesn't block
+    # Resolve subscribed events immediately so send() doesn't block.
+    # Use MSG_SENT with expected_ack because send_binary_req reads that key.
     def resolving_subscribe(event_type, cb, attribute_filters=None):
         sub = MagicMock()
         sub.unsubscribe = MagicMock()
+        payload = {"expected_ack": b"\x01\x02\x03\x04"} if event_type == EventType.MSG_SENT else {}
         asyncio.get_event_loop().call_soon(
-            cb, Event(event_type, {})
+            cb, Event(event_type, payload)
         )
         return sub
     handler.dispatcher.subscribe = MagicMock(side_effect=resolving_subscribe)

--- a/tests/unit/test_standalone_fixes.py
+++ b/tests/unit/test_standalone_fixes.py
@@ -1,6 +1,5 @@
 """
 Verification tests for standalone bug fixes and cleanup.
-Findings: F13, F09, M03, M05, M07, R03, R05.
 """
 
 import pytest
@@ -18,58 +17,58 @@ from meshcore.meshcore import MeshCore
 pytestmark = pytest.mark.asyncio
 
 
-# ── F13: req_mma removed ──────────────────────────────────────────────────────
+# ── req_mma removed ──────────────────────────────────────────────────────
 
-def test_f13_req_mma_removed():
-    """F13: The broken req_mma method should no longer exist on BinaryCommandHandler."""
+def test_req_mma_removed():
+    """The broken req_mma method should no longer exist on BinaryCommandHandler."""
     assert not hasattr(BinaryCommandHandler, "req_mma"), \
         "req_mma should be removed — it had NameError on undefined start/end"
 
 
-def test_f13_req_mma_sync_still_exists():
-    """F13: req_mma_sync should still be present and functional."""
+def test_req_mma_sync_still_exists():
+    """req_mma_sync should still be present and functional."""
     assert hasattr(BinaryCommandHandler, "req_mma_sync"), \
         "req_mma_sync should still exist after removing req_mma"
 
 
-# ── F09: DEFAULT_TIMEOUT bumped ───────────────────────────────────────────────
+# ── DEFAULT_TIMEOUT bumped ───────────────────────────────────────────────
 
-def test_f09_default_timeout_bumped():
-    """F09: DEFAULT_TIMEOUT should be 15.0, not the old 5.0."""
+def test_default_timeout_bumped():
+    """DEFAULT_TIMEOUT should be 15.0, not the old 5.0."""
     assert CommandHandlerBase.DEFAULT_TIMEOUT == 15.0, \
         f"DEFAULT_TIMEOUT is {CommandHandlerBase.DEFAULT_TIMEOUT}, expected 15.0"
 
 
-def test_f09_instance_default_timeout():
-    """F09: Instance default_timeout should inherit the new 15.0 value."""
+def test_instance_default_timeout():
+    """Instance default_timeout should inherit the new 15.0 value."""
     handler = CommandHandlerBase()
     assert handler.default_timeout == 15.0
 
 
-def test_f09_custom_timeout_still_works():
-    """F09: Passing a custom timeout should still override the default."""
+def test_custom_timeout_still_works():
+    """Passing a custom timeout should still override the default."""
     handler = CommandHandlerBase(default_timeout=30.0)
     assert handler.default_timeout == 30.0
 
 
-# ── M03: set_flood_scope TypeError guard ──────────────────────────────────────
+# ── set_flood_scope TypeError guard ──────────────────────────────────────
 
-async def test_m03_set_flood_scope_bad_type_raises():
-    """M03: Passing an unsupported type (e.g., int) should raise TypeError."""
+async def test_set_flood_scope_bad_type_raises():
+    """Passing an unsupported type (e.g., int) should raise TypeError."""
     handler = MessagingCommands()
     with pytest.raises(TypeError, match="unsupported scope type"):
         await handler.set_flood_scope(42)
 
 
-async def test_m03_set_flood_scope_bad_type_bytearray():
-    """M03: bytearray is not bytes — should raise TypeError."""
+async def test_set_flood_scope_bad_type_bytearray():
+    """bytearray is not bytes — should raise TypeError."""
     handler = MessagingCommands()
     with pytest.raises(TypeError, match="unsupported scope type"):
         await handler.set_flood_scope(bytearray(b"\x00" * 16))
 
 
-async def test_m03_set_flood_scope_none_still_works():
-    """M03: None scope should reach send() without TypeError — verifies the None branch still binds scope_key."""
+async def test_set_flood_scope_none_still_works():
+    """None scope should reach send() without TypeError — verifies the None branch still binds scope_key."""
     handler = MessagingCommands()
     handler._sender_func = AsyncMock()
     handler.dispatcher = EventDispatcher()
@@ -86,8 +85,8 @@ async def test_m03_set_flood_scope_none_still_works():
         handler.dispatcher.running = False
 
 
-async def test_m03_set_flood_scope_str_still_works():
-    """M03: String scope should reach send() without TypeError."""
+async def test_set_flood_scope_str_still_works():
+    """String scope should reach send() without TypeError."""
     handler = MessagingCommands()
     handler._sender_func = AsyncMock()
     handler.dispatcher = EventDispatcher()
@@ -103,8 +102,8 @@ async def test_m03_set_flood_scope_str_still_works():
         handler.dispatcher.running = False
 
 
-async def test_m03_set_flood_scope_bytes_still_works():
-    """M03: Bytes scope should reach send() without TypeError."""
+async def test_set_flood_scope_bytes_still_works():
+    """Bytes scope should reach send() without TypeError."""
     handler = MessagingCommands()
     handler._sender_func = AsyncMock()
     handler.dispatcher = EventDispatcher()
@@ -120,20 +119,20 @@ async def test_m03_set_flood_scope_bytes_still_works():
         handler.dispatcher.running = False
 
 
-# ── M05: dead path_hash_mode shift removed ────────────────────────────────────
+# ── dead path_hash_mode shift removed ────────────────────────────────────
 
-def test_m05_no_shift_in_update_contact():
-    """M05: The dead `>> 6` shift on out_path_len should not appear in contact.py."""
+def test_no_shift_in_update_contact():
+    """The dead `>> 6` shift on out_path_len should not appear in contact.py."""
     import meshcore.commands.contact as contact_mod
     source = inspect.getsource(contact_mod.ContactCommands.update_contact)
     assert ">> 6" not in source, \
         "Dead path_hash_mode = out_path_len >> 6 shift should be removed"
 
 
-# ── M07: get_contacts returns Event, never None ───────────────────────────────
+# ── get_contacts returns Event, never None ───────────────────────────────
 
-async def test_m07_get_contacts_timeout_returns_error_event():
-    """M07: On timeout (no futures complete), get_contacts should return an Error Event, not None."""
+async def test_get_contacts_timeout_returns_error_event():
+    """On timeout (no futures complete), get_contacts should return an Error Event, not None."""
     handler = ContactCommands()
     handler._sender_func = AsyncMock()
     handler._reader = MagicMock()
@@ -147,10 +146,10 @@ async def test_m07_get_contacts_timeout_returns_error_event():
     assert result.type == EventType.ERROR
 
 
-# ── R03: binary request pre-registration ──────────────────────────────────────
+# ── binary request pre-registration ──────────────────────────────────────
 
-async def test_r03_placeholder_registered_before_send():
-    """R03: A placeholder binary request should be registered before send() is called."""
+async def test_placeholder_registered_before_send():
+    """A placeholder binary request should be registered before send() is called."""
     from meshcore.packets import BinaryReqType
 
     handler = CommandHandlerBase()
@@ -198,10 +197,10 @@ async def test_r03_placeholder_registered_before_send():
         "register_binary_request should be called at least once for the placeholder"
 
 
-# ── R05: MeshCore.subscribe annotation matches EventDispatcher ────────────────
+# ── MeshCore.subscribe annotation matches EventDispatcher ────────────────
 
-def test_r05_subscribe_annotation_matches_dispatcher():
-    """R05: MeshCore.subscribe callback annotation should match EventDispatcher.subscribe."""
+def test_subscribe_annotation_matches_dispatcher():
+    """MeshCore.subscribe callback annotation should match EventDispatcher.subscribe."""
     mc_hints = MeshCore.subscribe.__annotations__
     ed_hints = EventDispatcher.subscribe.__annotations__
 
@@ -216,8 +215,8 @@ def test_r05_subscribe_annotation_matches_dispatcher():
     )
 
 
-def test_r05_no_coroutine_import_in_meshcore():
-    """R05: After widening the annotation, Coroutine should no longer be imported in meshcore.py."""
+def test_no_coroutine_import_in_meshcore():
+    """After widening the annotation, Coroutine should no longer be imported in meshcore.py."""
     import meshcore.meshcore as mc_mod
     source = inspect.getsource(mc_mod)
     # Check the import line specifically — Coroutine should not be in the typing imports

--- a/tests/unit/test_standalone_fixes.py
+++ b/tests/unit/test_standalone_fixes.py
@@ -1,5 +1,5 @@
 """
-Verification tests for G7 — Standalone bugs and cleanup.
+Verification tests for standalone bug fixes and cleanup.
 Findings: F13, F09, M03, M05, M07, R03, R05.
 """
 


### PR DESCRIPTION
**Base:** `upstream/main @ fbf84cb`
**Commits:** 10 (5 production + 3 verification/test-fix + 2 cleanup)
**Files touched:** `src/meshcore/commands/binary.py`, `src/meshcore/commands/base.py`, `src/meshcore/commands/messaging.py`, `src/meshcore/commands/contact.py`, `src/meshcore/meshcore.py`, `tests/unit/test_standalone_fixes.py`

---

**Forensics reference:** fix-group **G7** in the forensics report attached to issue #72. Finding IDs (`F09`, `F13`, `M03`, `M05`, `M07`, `R03`, `R05`) in the commit list below cross-reference specific sections of that report.

#### Summary

Catch-all PR for standalone bugs and cleanup items that don't fit the themed branches in the other PRs of this 8-PR batch (tracked in issue #72). Each fix is narrow and independent; bundling them into a single PR avoids opening ~5 micro-PRs for one-commit fixes.

**Structural theme:** this is explicitly the "everything else" branch. Each commit has its own rationale; bundling is for reviewer convenience, not logical coupling.

#### Why this bundle

These fixes are too small individually to justify their own PRs, and they don't fit any of the other themes. The `DEFAULT_TIMEOUT` bump (F09) is landed as a **separate commit** so the maintainer can drop just that commit with `git revert` if they push back on the value — the rest of the PR doesn't depend on it.

#### Commit rationale (already in commit messages — summarized)

1. **`0709b9f` — F13 remove broken `req_mma()` method.** Crashes with NameError on every call (references undefined `start` and `end`). A `logger.error` migration warning already in place confirms deprecation intent. Since it's broken as shipped, removing it can't break any working caller.
2. **`4204bf0` — F09 bump `DEFAULT_TIMEOUT` from 5s to 15s.** 5s is too short for slow-path mesh operations (path-resolving messaging, long binary responses, remote auth). **Landed as a separate commit so it can be dropped independently** if the maintainer prefers a different value.
3. **`aed7db2` — M03 + M05 + M07 minor cleanup.** M03: add `else: raise TypeError(...)` in `set_flood_scope` for unsupported scope types (prevents `UnboundLocalError`). M05: remove dead `path_hash_mode` shift in `update_contact` (high bits always zero due to reader masking). M07: normalize `get_contacts` three `None`-return branches to `Event(EventType.ERROR, ...)` to match the type annotation.
4. **`168e613` — R03 pre-register binary request placeholder before `send()`.** `send_binary_req` registered the pending request with the reader *after* `send()` returned. If BINARY_RESPONSE arrives between send and registration (reachable for TCP-companion proxies), the reader logs "No tracked request found" and the caller's `wait_for_event` times out. Pre-register a placeholder keyed by `id()`, swap for real tag from MSG_SENT. Closes the same race window as meshcore_py#52 but for the binary request path.
5. **`eb25984` — R05 widen `MeshCore.subscribe` callback annotation.** `MeshCore.subscribe` typed callbacks as async-only; `EventDispatcher.subscribe` typed them as the union sync/async. Type-checkers flag sync handlers routed through `MeshCore.subscribe`. Aligned with the dispatcher's union.
6. **`1a01770` — Verification tests** (15 tests covering F13, F09, M03, M05, M07, R03, R05).
7. **`4c1e5f4` + `74e349b` — Fix test_r03 mock resolution.** Two followups to the verification test: the bare MagicMock dispatcher didn't resolve event futures, causing test to block for 15s; added resolving subscribe mock and the MSG_SENT payload the code under test reads.

Plus 2 cleanup commits renaming test file and removing G-numbering / finding IDs from internals.

#### Related issues

**meshcore_py:**

- **#52** (closed, merged PR) — "subscribe before send to prevent event race condition" — **R03 extends this fix** to the binary request path (same subscribe-before-send race, different code site).

**meshcore-ha:** (links go to the meshcore-ha repo — separate from this PR's repo)

- https://github.com/meshcore-dev/meshcore-ha/issues/202 — F09 `DEFAULT_TIMEOUT` bump (5→15s) directly addresses slow-path timeout shortness. Worth calling out that this specific commit is isolated and droppable.
- https://github.com/meshcore-dev/meshcore-ha/issues/176 — plausibly related to 5s timeout on slow responses; F09 contributes.

#### Conflict with other PRs in this batch

- **Conflicts with PR #6 (`fix/asyncio-lifecycle`)** in `src/meshcore/commands/base.py`. See PR #78's conflict note.
- `src/meshcore/commands/contact.py` and `commands/messaging.py` also touched by PR #80 (`fix/protocol-surface-gaps`) — different regions, clean.
- `src/meshcore/meshcore.py` also touched by PR #3 (`fix/reconnect-path`) — different regions, clean.

#### Test plan

- `pytest tests/unit/test_standalone_fixes.py` — 15 new tests pass
- `pytest` — full suite passes, zero regressions