### PR TITLE
feat: add CHANNEL_DATA_RECV (RESP_CODE 27) packet type and handler

### DIFF
--- a/src/meshcore/events.py
+++ b/src/meshcore/events.py
@@ -14,6 +14,7 @@ class EventType(Enum):
     SELF_INFO = "self_info"
     CONTACT_MSG_RECV = "contact_message"
     CHANNEL_MSG_RECV = "channel_message"
+    CHANNEL_DATA_RECV = "channel_data"
     CURRENT_TIME = "time_update"
     NO_MORE_MSGS = "no_more_messages"
     CONTACT_URI = "contact_uri"

--- a/src/meshcore/packets.py
+++ b/src/meshcore/packets.py
@@ -105,6 +105,7 @@ class PacketType(Enum):
     STATS = 24
     AUTOADD_CONFIG = 25
     ALLOWED_REPEAT_FREQ = 26
+    CHANNEL_DATA_RECV = 27
     DEFAULT_FLOOD_SCOPE = 28
 
     # Push notifications

--- a/src/meshcore/reader.py
+++ b/src/meshcore/reader.py
@@ -332,6 +332,41 @@ class MessageReader:
                     Event(EventType.CHANNEL_MSG_RECV, res, attributes)
                 )
 
+            elif packet_type_value == PacketType.CHANNEL_DATA_RECV.value:
+                # Group-channel binary data (PAYLOAD_TYPE_GRP_DATA), companion-v1.15.0+.
+                # Fixed 9-byte header (including the code byte) + variable payload:
+                #   code(1) + snr(1) + reserved(2) + channel_idx(1)
+                #   + path_len(1) + data_type(2) + data_len(1) = 9 bytes
+                # The first six post-code bytes share CHANNEL_MSG_RECV_V3's framing;
+                # data_type is a 16-bit little-endian field (widened from uint8 in
+                # firmware, so the high byte may be non-zero).
+                if len(data) < 9:
+                    logger.debug(f"CHANNEL_DATA_RECV frame too short ({len(data)} bytes < 9), skipping parse")
+                    return
+                res = {}
+                res["SNR"] = int.from_bytes(dbuf.read(1), byteorder="little", signed=True) / 4
+                dbuf.read(2)  # reserved
+                res["channel_idx"] = dbuf.read(1)[0]
+                plen = dbuf.read(1)[0]
+                if plen == 255:  # direct message
+                    res["path_hash_mode"] = -1
+                    res["path_len"] = plen
+                else:
+                    res["path_hash_mode"] = plen >> 6
+                    res["path_len"] = plen & 0x3F
+                res["data_type"] = int.from_bytes(dbuf.read(2), byteorder="little")
+                res["data_len"] = dbuf.read(1)[0]
+                res["payload"] = dbuf.read(res["data_len"]).hex()
+
+                attributes = {
+                    "channel_idx": res["channel_idx"],
+                    "data_type": res["data_type"],
+                }
+
+                await self.dispatcher.dispatch(
+                    Event(EventType.CHANNEL_DATA_RECV, res, attributes)
+                )
+
             elif packet_type_value == PacketType.CURRENT_TIME.value:
                 time_value = int.from_bytes(dbuf.read(4), byteorder="little")
                 result = {"time": time_value}

--- a/tests/unit/test_protocol_surface_gaps.py
+++ b/tests/unit/test_protocol_surface_gaps.py
@@ -362,3 +362,127 @@ async def test_get_stats_core_uses_enum():
     assert captured_data is not None
     assert captured_data[0] == CommandType.GET_STATS.value  # 0x38 = 56
     assert captured_data[1] == 0x00
+
+
+# ---------------------------------------------------------------------------
+# CHANNEL_DATA_RECV handler + enum entry (group-channel binary data)
+# ---------------------------------------------------------------------------
+
+def test_channel_data_recv_enum_exists():
+    """PacketType.CHANNEL_DATA_RECV == 27 (the previously-skipped enum slot)."""
+    assert PacketType.CHANNEL_DATA_RECV.value == 27
+
+
+@pytest.mark.asyncio
+async def test_channel_data_recv_direct_path_frame():
+    """A realistic direct-path CHANNEL_DATA_RECV frame dispatches the typed payload.
+
+    Frame: code + snr(0x10) + reserved(00 00) + channel_idx(1)
+           + path_len(0xFF direct) + data_type(0x0123 LE) + data_len(4)
+           + payload(DEADBEEF).
+    """
+    reader, dispatched = _make_reader()
+    frame = bytes([
+        PacketType.CHANNEL_DATA_RECV.value,
+        0x10,              # SNR (signed int8) -> 16 / 4 = 4.0
+        0x00, 0x00,        # reserved
+        0x01,              # channel_idx
+        0xFF,              # path_len sentinel -> direct message
+        0x23, 0x01,        # data_type = 0x0123 (uint16 little-endian)
+        0x04,              # data_len
+        0xDE, 0xAD, 0xBE, 0xEF,  # payload
+    ])
+    assert len(frame) == 13
+
+    await reader.handle_rx(bytearray(frame))
+
+    assert len(dispatched) == 1
+    evt = dispatched[0]
+    assert evt.type == EventType.CHANNEL_DATA_RECV
+    assert evt.payload["SNR"] == 4.0
+    assert evt.payload["channel_idx"] == 1
+    assert evt.payload["path_len"] == 255
+    assert evt.payload["path_hash_mode"] == -1
+    assert evt.payload["data_type"] == 0x0123
+    assert evt.payload["data_len"] == 4
+    assert evt.payload["payload"] == "deadbeef"
+    assert evt.attributes["channel_idx"] == 1
+    assert evt.attributes["data_type"] == 0x0123
+
+
+@pytest.mark.asyncio
+async def test_channel_data_recv_route_flood_path_len_bits():
+    """A route-flood path_len byte splits into hash-mode (>>6) and length (&0x3F).
+
+    path_len = 0x42 = 0b01000010 -> hash_mode = 1, length = 2.
+    """
+    reader, dispatched = _make_reader()
+    frame = bytes([
+        PacketType.CHANNEL_DATA_RECV.value,
+        0x10,              # SNR
+        0x00, 0x00,        # reserved
+        0x02,              # channel_idx
+        0x42,              # path_len -> hash_mode 1, length 2
+        0x00, 0x00,        # data_type = 0
+        0x02,              # data_len
+        0xAA, 0xBB,        # payload
+    ])
+    assert len(frame) == 11
+
+    await reader.handle_rx(bytearray(frame))
+
+    assert len(dispatched) == 1
+    evt = dispatched[0]
+    assert evt.type == EventType.CHANNEL_DATA_RECV
+    assert evt.payload["path_hash_mode"] == 1
+    assert evt.payload["path_len"] == 2
+    assert evt.payload["channel_idx"] == 2
+    assert evt.payload["data_type"] == 0
+    assert evt.payload["data_len"] == 2
+    assert evt.payload["payload"] == "aabb"
+
+
+@pytest.mark.asyncio
+async def test_channel_data_recv_under_minimum_frame_ignored():
+    """A CHANNEL_DATA_RECV frame shorter than the 9-byte header is dropped."""
+    reader, dispatched = _make_reader()
+    # 8 bytes total (header needs 9) — missing the data_len byte.
+    frame = bytes([
+        PacketType.CHANNEL_DATA_RECV.value,
+        0x10, 0x00, 0x00, 0x01, 0xFF, 0x00, 0x00,
+    ])
+    assert len(frame) == 8
+
+    await reader.handle_rx(bytearray(frame))
+
+    assert len(dispatched) == 0
+
+
+@pytest.mark.asyncio
+async def test_channel_data_recv_widened_data_type():
+    """data_type is a 16-bit field: a value > 0xFF round-trips through the 2-byte read.
+
+    data_type = 0x0201 (513) confirms the high byte is not truncated. data_len = 0
+    exercises the empty-payload tail.
+    """
+    reader, dispatched = _make_reader()
+    frame = bytes([
+        PacketType.CHANNEL_DATA_RECV.value,
+        0x10,              # SNR
+        0x00, 0x00,        # reserved
+        0x00,              # channel_idx
+        0xFF,              # path_len direct
+        0x01, 0x02,        # data_type = 0x0201 (little-endian)
+        0x00,              # data_len = 0
+    ])
+    assert len(frame) == 9
+
+    await reader.handle_rx(bytearray(frame))
+
+    assert len(dispatched) == 1
+    evt = dispatched[0]
+    assert evt.type == EventType.CHANNEL_DATA_RECV
+    assert evt.payload["data_type"] == 0x0201
+    assert evt.payload["data_type"] > 0xFF
+    assert evt.payload["data_len"] == 0
+    assert evt.payload["payload"] == ""


### PR DESCRIPTION
### Summary

Adds SDK support for the `CHANNEL_DATA_RECV` push frame (`RESP_CODE_CHANNEL_DATA_RECV = 27`), which the companion-radio firmware emits for group-channel binary data (`PAYLOAD_TYPE_GRP_DATA` — e.g. LPP-encoded telemetry or other binary blobs delivered over a shared channel). Before this change the SDK had no `PacketType` value for 27 (the enum jumped from `ALLOWED_REPEAT_FREQ = 26` straight to `DEFAULT_FLOOD_SCOPE = 28`), no `EventType`, and no reader handler, so these frames hit the unknown-packet-type fallthrough in `handle_rx` and the payload was silently dropped.

### What changed

- `packets.py`: add `PacketType.CHANNEL_DATA_RECV = 27` in the previously-skipped enum slot.
- `events.py`: add `EventType.CHANNEL_DATA_RECV = "channel_data"`.
- `reader.py`: add a handler that decodes the fixed 9-byte header (including the code byte) plus the variable payload, then dispatches an `EventType.CHANNEL_DATA_RECV` event.
- `tests/unit/test_protocol_surface_gaps.py`: 5 new tests.

### Wire format

The firmware emits the frame from `MyMesh::onChannelDataRecv()`:

| Offset | Width | Field |
|---|---|---|
| 0 | 1B | `RESP_CODE_CHANNEL_DATA_RECV` (27) |
| 1 | 1B | SNR × 4 (signed int8) |
| 2–3 | 2B | reserved (0) |
| 4 | 1B | `channel_idx` |
| 5 | 1B | `path_len` (route-flood) or `0xFF` (direct) |
| 6–7 | 2B | `data_type` (uint16, little-endian) |
| 8 | 1B | `data_len` |
| 9+ | N B | payload (`data_len` bytes) |

The first six post-code bytes (SNR, reserved, `channel_idx`, `path_len` with its sentinel/hash-mode encoding) are byte-for-byte identical in shape to `CHANNEL_MSG_RECV_V3`, so the decode of that prefix reuses the existing convention directly. The only genuinely new decode is the typed `data_type` / `data_len` / payload tail.

### Firmware history

The feature shipped across three firmware commits, all first contained in release **companion-v1.15.0**:

- `9b842786` (2026-03-05) — `feat: Add support for PAYLOAD_TYPE_GRP_DATA` — initial feature.
- `f25d7a88` — `fix: Align channel data framing` — framing alignment.
- `2f687691` (2026-03-19) — `fix: Widen grp data type` — widened `data_type` from `uint8_t` to `uint16_t`, which is why `data_type` is decoded as a 2-byte little-endian field (offsets 6–7) rather than a single byte.

### Design choices

These default to the SDK's existing conventions rather than introducing new patterns; happy to adjust any of them on review:

- **`data_type` exposed as an `int`** — mirrors the `txt_type` convention in `CHANNEL_MSG_RECV_V3`. The raw integer preserves the on-wire value for any consumer that wants to dispatch on it directly; a parsed enum could be layered on later without a breaking change.
- **`data_len` exposed as an `int`** — lets consumers validate payload integrity independent of `len(payload) // 2`.
- **`payload` exposed as a hex string** — mirrors `RAW_DATA`'s convention for binary data of unknown encoding. It is read as exactly `data_len` bytes (the firmware treats `data_len` as authoritative) rather than "read remainder", so any trailer bytes are not folded into the payload.
- **`attributes` surfaces `channel_idx` and `data_type`** — mirrors how `CHANNEL_MSG_RECV_V3` surfaces `channel_idx` and `txt_type`, so subscribers can filter without unpacking the payload.
- **Up-front length gate** (`len(data) < 9` → debug-log and return) — matches the defensive-read pattern used by the other handlers; protects against truncated frames.

### Tests

`tests/unit/test_protocol_surface_gaps.py` adds:

1. `test_channel_data_recv_enum_exists` — `PacketType.CHANNEL_DATA_RECV == 27`.
2. `test_channel_data_recv_direct_path_frame` — realistic direct-path frame (`path_len = 0xFF`, `data_type = 0x0123`, 4-byte payload); asserts every decoded field including `payload == "deadbeef"`.
3. `test_channel_data_recv_route_flood_path_len_bits` — `path_len = 0x42` splits into `hash_mode = 1`, `length = 2`.
4. `test_channel_data_recv_under_minimum_frame_ignored` — 8-byte frame returns early, no dispatch.
5. `test_channel_data_recv_widened_data_type` — `data_type = 0x0201` confirms the high byte survives the 2-byte read; empty-payload tail.

Full unit suite passes (no regressions).

### Notes for the maintainer

- An SDK convenience method (e.g. `subscribe_channel_data(channel_idx, callback)`) was deliberately left out — consumers can use the event dispatcher directly. Happy to add it if you'd prefer the helper.
- The field names and types above follow existing SDK conventions, but this is the first new public packet type on the channel-receive surface, so naming/shape feedback is welcome — see the design-choices section for the rationale behind each.
- Submitted alongside sibling PR #87 (wire-format parity fixes). Both branch off `v2.3.7` and both touch `reader.py`, so whichever merges second will need a trivial rebase.