### PR TITLE
test: fix send_raw_data_wrapper for the 4-byte guard and path_len framing

### DIFF
--- a/tests/unit/test_protocol_surface_gaps.py
+++ b/tests/unit/test_protocol_surface_gaps.py
@@ -186,7 +186,7 @@ async def test_send_trace_with_path_no_padding():
 
 @pytest.mark.asyncio
 async def test_send_raw_data_wrapper():
-    """send_raw_data sends CMD 0x19 + payload."""
+    """send_raw_data sends CMD 0x19 + path_len + payload."""
     from meshcore.commands.messaging import MessagingCommands
 
     cmd = MessagingCommands.__new__(MessagingCommands)
@@ -200,11 +200,12 @@ async def test_send_raw_data_wrapper():
 
     cmd.send = mock_send
 
-    await cmd.send_raw_data(b"\xDE\xAD")
+    await cmd.send_raw_data(b"\xDE\xAD\xBE\xEF")
 
     assert captured_data is not None
     assert captured_data[0] == 0x19  # CMD_SEND_RAW_DATA
-    assert captured_data[1:] == b"\xDE\xAD"
+    assert captured_data[1] == 0x00  # path_len: zero-hop direct (empty path)
+    assert captured_data[2:] == b"\xDE\xAD\xBE\xEF"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to the #87 review thread: `test_send_raw_data_wrapper` fails on current `main`.

#86 (`44b21be`) reworked `send_raw_data` to frame as `0x19 | path_len(1) | path | payload` and to reject payloads under 4 bytes, but the test wasn't updated alongside it. On `main` it now fails: it sends a 2-byte payload (raising `ValueError: payload must be at least 4 bytes` before any assertion), and its `captured_data[1:] == payload` assertion no longer accounts for the inserted `path_len` byte.

Per @fdlamotte in #87 — the firmware drops payloads under 4 bytes, so the guard is correct — this fixes the test, not the guard:

- payload bumped to 4 bytes (`\xDE\xAD\xBE\xEF`)
- assert the zero `path_len` byte, then the payload at offset 2

Validates the wire format #86 introduced rather than the pre-#86 `0x19 | payload` shape.

### Tests

Full unit suite passes (`test_send_raw_data_wrapper` was the lone failure on current `main`).