### PR TITLE
fix: TCP RX frame marker should be 0x3c (not 0x3e)

### DIFF
--- a/src/meshcore/tcp_cx.py
+++ b/src/meshcore/tcp_cx.py
@@ -73,8 +73,8 @@ class TCPConnection:
 
     def handle_rx(self, data: bytearray):
         if len(self.header) == 0: # did not find start of frame yet
-            # search start of frame (0x3e) in data
-            idx = data.find(b"\x3e")
+            # search start of frame (0x3c) in data
+            idx = data.find(b"\x3c")
             if idx < 0: # no start of frame
                 return
             # Discard any leading junk bytes before the actual frame marker.


### PR DESCRIPTION
## Summary

Fixes the TCP RX frame marker mismatch that prevents `MeshCore.create_tcp()` from working when connecting through **meshcore-proxy**.

## The Bug

`TCPConnection.handle_rx()` in `src/meshcore/tcp_cx.py` was looking for `0x3e` as the frame marker, but meshcore-proxy (and the TCP `send()` method itself) uses `0x3c`.

- **TX** (send): `0x3c + 2-byte LE size + payload` ✅
- **RX** (handle_rx): was looking for `0x3e` ❌ → now `0x3c` ✅

## Root Cause

The `0x3e` marker is the **Serial/BLE protocol** start-of-frame. When the TCP connection class was originally written, the RX marker was mistakenly copied from the serial implementation instead of using the same `0x3c` marker that the TX path already uses.

## Changes

`src/meshcore/tcp_cx.py` — line 76 (comment) and line 77 (code):
- Comment: `(0x3e)` → `(0x3c)`
- Code: `data.find(b"\x3e")` → `data.find(b"\x3c")`

## Testing

Without this fix: `MeshCore.create_tcp()` through meshcore-proxy → "No response from meshcore node" after timeout.
With this fix: connects successfully, receives `SELF_INFO`, and can subscribe to `CONTACT_MSG_RECV` events.

## Related

Closes #93